### PR TITLE
cmake: Add standard cmake build dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.creator*
 *.files
 *.includes
+build


### PR DESCRIPTION
The standard practice for CMake is to use a build directory...

```
mkdir build
cd build
cmake ..
make
```