### PR TITLE
Break CMake logic out, add install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,65 +1,56 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.12)
 project(tinygl
-    DESCRIPTION "tinygl: The ultimate portable graphics library"
-    HOMEPAGE_URL "https://github.com/C-Chads/tinygl"
-    LANGUAGES C
-)
+  DESCRIPTION "tinygl: The ultimate portable graphics library"
+  HOMEPAGE_URL "https://github.com/C-Chads/tinygl"
+  LANGUAGES C
+  )
+
+# Set relative output directory paths, if not already defined
+if (NOT BIN_DIR)
+  set(BIN_DIR bin)
+endif (NOT BIN_DIR)
+if (NOT INCLUDE_DIR)
+  set(INCLUDE_DIR include)
+endif (NOT INCLUDE_DIR)
+if (NOT DEFINED LIB_DIR)
+  set(LIB_DIR lib)
+endif (NOT DEFINED LIB_DIR)
+
+# Check for a math library
+include(CheckLibraryExists)
+check_library_exists(m cos "" HAVE_M_LIBRARY)
+if (HAVE_M_LIBRARY)
+  set(M_LIBRARY m)
+endif (HAVE_M_LIBRARY)
 
 # Options
 option(TINYGL_BUILD_EXAMPLES "Build Examples" OFF)
-option(TINYGL_BUILD_STATIC "Build Static Library" ON)
 option(TINYGL_BUILD_SHARED "Build Shared Library" ON)
+option(TINYGL_BUILD_STATIC "Build Static Library" ON)
 
-# Variables
-set(TINYGL_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
-set(TINYGL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
-file(GLOB TINYGL_SOURCES ${TINYGL_SOURCE_DIR}/*.c)
+# Build main library
+add_subdirectory(src)
 
-# Libraries
-if(TINYGL_BUILD_STATIC)
-    add_library(tinygl-static STATIC ${TINYGL_SOURCES})
-    target_include_directories(tinygl-static PUBLIC ${TINYGL_INCLUDE_DIR})
-endif()
-if(TINYGL_BUILD_SHARED)
-    add_library(tinygl SHARED ${TINYGL_SOURCES})
-    target_include_directories(tinygl PUBLIC ${TINYGL_INCLUDE_DIR})
-endif()
+# Install logic for headers
+add_subdirectory(include)
 
 # Examples
-if(TINYGL_BUILD_EXAMPLES AND TINYGL_BUILD_STATIC)
-    set(TINYGL_DEMOS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Raw_Demos)
-    file(GLOB TINYGL_DEMOS ${TINYGL_DEMOS_DIR}/*.c)
-    foreach(DEMO ${TINYGL_DEMOS})
-        get_filename_component(DEMO_NAME ${DEMO} NAME_WE)
-        add_executable(${DEMO_NAME} ${DEMO})
-        target_link_libraries(${DEMO_NAME} tinygl-static m)
-    endforeach()
-    configure_file(${TINYGL_DEMOS_DIR}/asciifractal.sh asciifractal.sh)
-    configure_file(${TINYGL_DEMOS_DIR}/char.txt char.txt)
+if(TINYGL_BUILD_EXAMPLES)
 
-    find_package(SDL QUIET)
-    if(SDL_FOUND)
-        set(TINYGL_SDL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/SDL_Examples)
-        file(GLOB TINYGL_SDL_DEMOS ${TINYGL_SDL_DIR}/*.c)
-        foreach(DEMO ${TINYGL_SDL_DEMOS})
-            get_filename_component(DEMO_NAME ${DEMO} NAME_WE)
-            set(DEMO_NAME "sdl_${DEMO_NAME}")
-            add_executable(${DEMO_NAME} ${DEMO})
-            target_link_libraries(${DEMO_NAME} tinygl-static m ${SDL_LIBRARY})
-            target_include_directories(${DEMO_NAME} PUBLIC ${SDL_INCLUDE_DIR})
-        endforeach()
+  # These deliberately do not depend on SDL.  TODO - these could be used to
+  # drive a "make test" system to check the correct functioning of the library
+  # after compilation...
+  add_subdirectory(Raw_Demos)
 
-        file(GLOB TINYGL_RESOURCES
-            ${TINYGL_SDL_DIR}/*.png
-            ${TINYGL_SDL_DIR}/*.obj
-            ${TINYGL_SDL_DIR}/*.mp3
-            ${TINYGL_SDL_DIR}/*.jpg
-        )
-        foreach(FILE ${TINYGL_RESOURCES})
-            get_filename_component(FILE_NAME ${FILE} NAME)
-            configure_file(${FILE} ${FILE_NAME} COPYONLY)
-        endforeach()
-    else()
-        message(STATUS "tinygl: SDL not found")
-    endif()
+  # Examples that use SDL for interactive display
+  add_subdirectory(SDL_Examples)
+
 endif()
+
+# Local Variables:
+# tab-width: 8
+# mode: cmake
+# indent-tabs-mode: t
+# End:
+# ex: shiftwidth=2 tabstop=8
+

--- a/Raw_Demos/CMakeLists.txt
+++ b/Raw_Demos/CMakeLists.txt
@@ -1,0 +1,29 @@
+if(TARGET tinygl)
+  set(TINYGL_LIB tinygl)
+elseif(TARGET tinygl-static)
+  set(TINYGL_LIB tinygl-static)
+endif(TARGET tinygl)
+
+if(TINYGL_LIB)
+
+  set(raw_names gears t2i bigfont)
+  foreach(DEMO ${demo_names})
+    set(DEMO_NAME "raw_${DEMO}")
+    add_executable(${DEMO_NAME} ${DEMO}.c)
+    target_link_libraries(${DEMO_NAME} ${TINYGL_LIB} ${M_LIBRARY})
+    target_include_directories(${DEMO_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+  endforeach()
+
+  # Copy utility files to build dir
+  configure_file(asciifractal.sh ${CMAKE_CURRENT_BINARY_DIR}/asciifractal.sh)
+  configure_file(char.txt ${CMAKE_CURRENT_BINARY_DIR}/char.txt)
+
+endif(TINYGL_LIB)
+
+# Local Variables:
+# tab-width: 8
+# mode: cmake
+# indent-tabs-mode: t
+# End:
+# ex: shiftwidth=2 tabstop=8
+

--- a/SDL_Examples/CMakeLists.txt
+++ b/SDL_Examples/CMakeLists.txt
@@ -1,0 +1,50 @@
+find_package(SDL QUIET)
+
+if(SDL_FOUND)
+
+  if(TARGET tinygl)
+    set(TINYGL_LIB tinygl)
+  elseif(TARGET tinygl-static)
+    set(TINYGL_LIB tinygl-static)
+  endif()
+
+  if (TINYGL_LIB)
+
+    set(demo_names game gears helloworld menu model texture)
+    foreach(DEMO ${demo_names})
+      set(DEMO_NAME "sdl_${DEMO}")
+      add_executable(${DEMO_NAME} ${DEMO}.c)
+      target_link_libraries(${DEMO_NAME} ${TINYGL_LIB} ${M_LIBRARY} ${SDL_LIBRARY})
+      target_include_directories(${DEMO_NAME} PUBLIC ${SDL_INCLUDE_DIR})
+    endforeach()
+
+    set(TINYGL_RESOURCES
+      Arnepalette.png
+      WWGW.mp3
+      extrude.obj
+      monkey3.obj
+      tex.jpg
+      tex_hole.png
+      tex_old.jpg
+      texture.png
+      )
+    foreach(FILE ${TINYGL_RESOURCES})
+      get_filename_component(FILE_NAME ${FILE} NAME)
+      configure_file(${FILE} ${FILE_NAME} COPYONLY)
+    endforeach()
+
+  endif (TINYGL_LIB)
+
+else(SDL_FOUND)
+
+  message(STATUS "tinygl: SDL not found")
+
+endif(SDL_FOUND)
+
+# Local Variables:
+# tab-width: 8
+# mode: cmake
+# indent-tabs-mode: t
+# End:
+# ex: shiftwidth=2 tabstop=8
+

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(zhdrs
+	zbuffer.h
+	zfeatures.h
+	)
+
+install(FILES ${zhdrs} DESTINATION ${INCLUDE_DIR})
+
+install(FILES GL/gl.h DESTINATION ${INCLUDE_DIR}/TGL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,58 @@
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+set(tinygl_srcs
+  accum.c
+  api.c
+  arrays.c
+  clear.c
+  clip.c
+  get.c
+  image_util.c
+  init.c
+  light.c
+  list.c
+  matrix.c
+  memory.c
+  misc.c
+  msghandling.c
+  select.c
+  specbuf.c
+  texture.c
+  vertex.c
+  zbuffer.c
+  zline.c
+  zmath.c
+  zpostprocess.c
+  zraster.c
+  ztext.c
+  ztriangle.c
+  )
+
+if(TINYGL_BUILD_STATIC)
+  add_library(tinygl SHARED ${tinygl_srcs})
+  target_include_directories(tinygl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+  install(TARGETS tinygl
+    RUNTIME DESTINATION ${BIN_DIR}
+    LIBRARY DESTINATION ${LIB_DIR}
+    ARCHIVE DESTINATION ${LIB_DIR})
+  if(NOT MSVC)
+    target_compile_options(tinygl PRIVATE "-Wall")
+  endif(NOT MSVC)
+endif(TINYGL_BUILD_STATIC)
+
+if(TINYGL_BUILD_STATIC)
+  add_library(tinygl-static STATIC ${tinygl_srcs})
+  target_include_directories(tinygl-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+  install(TARGETS tinygl-static
+    RUNTIME DESTINATION ${BIN_DIR}
+    LIBRARY DESTINATION ${LIB_DIR}
+    ARCHIVE DESTINATION ${LIB_DIR})
+endif(TINYGL_BUILD_STATIC)
+
+# Local Variables:
+# tab-width: 8
+# mode: cmake
+# indent-tabs-mode: t
+# End:
+# ex: shiftwidth=2 tabstop=8
+


### PR DESCRIPTION
Switching GLOB calls out in favor of explicit lists
(https://cmake.org/cmake/help/latest/command/file.html#glob)

Add install rules for tinygl libs and headers.