### PR TITLE
Some tweaks to git's ignore and keep rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,12 @@
 *.creator*
 *.files
 *.includes
+
+# Ignore build outputs
 build
+src/*.o
+src/*.a
+Raw_Demos/bigfont
+Raw_Demos/gears
+Raw_Demos/t2i
+lib/*.a

--- a/lib/keep_alive.txt
+++ b/lib/keep_alive.txt
@@ -1,1 +1,0 @@
-hey git could you not delete this folder thanks


### PR DESCRIPTION
This PR does two things to improve how git handles generated files.

 - `lib/keep_alive.txt` is replaced with the standard `.gitkeep` file for this purpose. 
 - The gitignore has a few new rules to handle the output of a `make` command