### PR TITLE
Use sdl-config to get the SDL include path

### DIFF
--- a/SDL_Examples/Makefile
+++ b/SDL_Examples/Makefile
@@ -7,7 +7,9 @@ ALL_T= gears texture model helloworld menu game
 LIB= ../lib/libTinyGL.a
 
 #For GCC on good OSes:
-SDL_LIBS= -lSDL 
+SDL_CONFIG?=sdl-config
+SDL_CFLAGS=$(shell $(SDL_CONFIG) --cflags)
+SDL_LIBS=$(shell $(SDL_CONFIG) --libs)
 #for MinGW users:
 #SDL_LIBS= -lmingw32 -lSDLmain -lSDL 
 
@@ -18,14 +20,14 @@ all: $(ALL_T)
 clean:
 	rm -f $(ALL_T) *.exe
 texture:
-	$(CC) texture.c $(LIB) -o texture $(GL_INCLUDES) $(SDL_LIBS) $(SDL_MIXERLIBS) $(GL_LIBS) $(CFLAGS) -lm
+	$(CC) texture.c $(LIB) -o texture $(SDL_CFLAGS) $(GL_INCLUDES) $(SDL_LIBS) $(SDL_MIXERLIBS) $(GL_LIBS) $(CFLAGS) -lm
 menu:
-	$(CC) menu.c $(LIB) -o menu $(GL_INCLUDES) $(SDL_LIBS) $(SDL_MIXERLIBS) $(GL_LIBS) $(CFLAGS) -lm
+	$(CC) menu.c $(LIB) -o menu $(SDL_CFLAGS) $(GL_INCLUDES) $(SDL_LIBS) $(SDL_MIXERLIBS) $(GL_LIBS) $(CFLAGS) -lm
 helloworld:
-	$(CC) helloworld.c $(LIB) -o helloworld $(GL_INCLUDES) $(GL_LIBS) $(CFLAGS) $(SDL_LIBS) $(SDL_MIXERLIBS) -lm
+	$(CC) helloworld.c $(LIB) -o helloworld $(SDL_CFLAGS) $(GL_INCLUDES) $(GL_LIBS) $(CFLAGS) $(SDL_LIBS) $(SDL_MIXERLIBS) -lm
 model:
-	$(CC) model.c $(LIB) -o model $(GL_INCLUDES) $(GL_LIBS) $(CFLAGS) $(SDL_LIBS) $(SDL_MIXERLIBS) -lm
+	$(CC) model.c $(LIB) -o model $(SDL_CFLAGS) $(GL_INCLUDES) $(GL_LIBS) $(CFLAGS) $(SDL_LIBS) $(SDL_MIXERLIBS) -lm
 game:
-	$(CC) game.c $(LIB) -o game $(GL_INCLUDES) $(GL_LIBS) $(CFLAGS) $(SDL_LIBS) $(SDL_MIXERLIBS) -lm
+	$(CC) game.c $(LIB) -o game $(SDL_CFLAGS) $(GL_INCLUDES) $(GL_LIBS) $(CFLAGS) $(SDL_LIBS) $(SDL_MIXERLIBS) -lm
 gears:
-	$(CC) gears.c $(LIB) -o gears $(GL_INCLUDES) $(GL_LIBS) $(CFLAGS) $(SDL_LIBS) $(SDL_MIXERLIBS) -lm
+	$(CC) gears.c $(LIB) -o gears $(SDL_CFLAGS) $(GL_INCLUDES) $(GL_LIBS) $(CFLAGS) $(SDL_LIBS) $(SDL_MIXERLIBS) -lm

--- a/SDL_Examples/game.c
+++ b/SDL_Examples/game.c
@@ -19,7 +19,7 @@
 #else
 typedef unsigned char uchar;
 #endif
-#include <SDL/SDL.h>
+#include <SDL.h>
 #include <time.h>
 int noSDL = 0;
 int doblend = 0;

--- a/SDL_Examples/gears.c
+++ b/SDL_Examples/gears.c
@@ -21,7 +21,7 @@
 #else
 typedef unsigned char uchar;
 #endif
-#include <SDL/SDL.h>
+#include <SDL.h>
 int noSDL = 0;
 #ifndef M_PI
 #define M_PI 3.14159265

--- a/SDL_Examples/helloworld.c
+++ b/SDL_Examples/helloworld.c
@@ -17,7 +17,7 @@
 #else
 typedef unsigned char uchar;
 #endif
-#include <SDL/SDL.h>
+#include <SDL.h>
 int noSDL = 0;
 int do2 = 0;
 #ifndef M_PI

--- a/SDL_Examples/menu.c
+++ b/SDL_Examples/menu.c
@@ -23,7 +23,7 @@ Demo of Gek's proposed Open Immediate Mode Gui Standard
 #else
 typedef unsigned char uchar;
 #endif
-#include <SDL/SDL.h>
+#include <SDL.h>
 
 // Gek's OpenIMGUI standard.
 #define OPENIMGUI_IMPL

--- a/SDL_Examples/model.c
+++ b/SDL_Examples/model.c
@@ -19,7 +19,7 @@
 #else
 typedef unsigned char uchar;
 #endif
-#include <SDL/SDL.h>
+#include <SDL.h>
 #include <time.h>
 int noSDL = 0;
 int doblend = 0;

--- a/SDL_Examples/texture.c
+++ b/SDL_Examples/texture.c
@@ -23,7 +23,7 @@ typedef unsigned char uchar;
 #endif
 #define STB_IMAGE_IMPLEMENTATION
 #include "../include-demo/stb_image.h"
-#include <SDL/SDL.h>
+#include <SDL.h>
 int noSDL = 0;
 int doPostProcess = 0;
 


### PR DESCRIPTION
This matches how CMake behaves, and fixes compilation when SDL is installed in a non-default location.