### PR TITLE
Fix global buffer overflow at glMaterialfv

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -378,7 +378,7 @@ void glMaterialfv(GLint mode, GLint type, GLfloat* v) {
 	n = 4;  /* This appears to be a hack... to avoid a jump instruction? What the hell?*/
 	if (type == GL_SHININESS)
 		n = 1;
-	for (i = 0; i < 4; i++)
+	for (i = 0; i < n; i++)
 		p[3 + i].f = v[i];
 	for (i = n; i < 4; i++)
 		p[3 + i].f = 0;


### PR DESCRIPTION
I found a global buffer overflow on glMaterialfv.
It define shininess as a global variable.
https://github.com/C-Chads/tinygl/blob/a256a597ea623ff8972fe332e7c9f352e9f36c20/Raw_Demos/gears.c#L252
And run glMaterialfv.
https://github.com/C-Chads/tinygl/blob/a256a597ea623ff8972fe332e7c9f352e9f36c20/Raw_Demos/gears.c#L273
But in glMaterialfv, it try to read shininess[1] to shininess[3], I think read `v[i]` should decide by `n` to prevent over read when type is GL_SHININESS
https://github.com/C-Chads/tinygl/blob/a256a597ea623ff8972fe332e7c9f352e9f36c20/src/api.c#L378-L384